### PR TITLE
Improve business context quick actions layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,18 +137,24 @@
             </div>
         </div>
 
-        <div class="lg:col-span-2 flex flex-col gap-6">
-            <div class="agentic-pane flex-1 overflow-hidden">
-                <h2 class="text-lg font-bold p-4 border-b text-slate-700 flex-shrink-0">Tool Catalog</h2>
-                <div id="tool-catalog" class="p-4 space-y-3 overflow-y-auto">
+        <div class="lg:col-span-2 flex flex-col gap-6 min-h-[calc(100vh-120px)]">
+            <div class="agentic-pane flex-[3] overflow-hidden flex flex-col">
+                <div class="p-4 border-b text-slate-700">
+                    <h2 class="text-lg font-bold">Tool Catalog</h2>
+                    <p class="text-xs text-slate-500 mt-1">Browse the assistant's connected tools by category and trigger them instantly.</p>
+                </div>
+                <div id="tool-catalog" class="flex-1 p-4 space-y-5 overflow-y-auto bg-slate-50/40">
                     <div class="flex items-center justify-center h-full text-slate-400">
                         <i class="fa fa-spinner fa-spin mr-2"></i> Loading Tools...
                     </div>
                 </div>
             </div>
-            <div class="agentic-pane flex-1 overflow-hidden">
-                <h2 class="text-lg font-bold p-4 border-b text-slate-700 flex-shrink-0">Quick Actions</h2>
-                <div id="quick-actions-list" class="p-4 overflow-y-auto"></div>
+            <div class="agentic-pane flex-[2] overflow-hidden flex flex-col">
+                <div class="p-4 border-b text-slate-700">
+                    <h2 class="text-lg font-bold">Business Context & Quick Actions</h2>
+                    <p class="text-xs text-slate-500 mt-1">Choose a business from mock data and launch ready-made prompts tailored to it.</p>
+                </div>
+                <div id="quick-actions-list" class="flex-1 p-4 space-y-5 overflow-y-auto bg-slate-50/40"></div>
             </div>
         </div>
     </main>
@@ -240,12 +246,114 @@
                 { label: "Business report", prompt: "Generate a business performance report", icon: "fa-chart-pie", accent: "bg-emerald-100 text-emerald-600" },
                 { label: "Review count", prompt: "What is the current review count?", icon: "fa-star", accent: "bg-amber-100 text-amber-600" }
             ];
+
+            const businesses = [
+                {
+                    id: 'qtick-wellness',
+                    name: 'QTick Wellness Hub',
+                    industry: 'Wellness & Spa',
+                    location: 'Marina Bay, Singapore',
+                    manager: 'Anita Chandra',
+                    contact: '+65 6550 1122',
+                    tagline: 'Holistic therapies with a modern twist',
+                    metrics: {
+                        appointments: 128,
+                        satisfaction: '4.8 / 5',
+                        revenue: '$18.2K'
+                    }
+                },
+                {
+                    id: 'glow-grow-spa',
+                    name: 'Glow & Grow Spa',
+                    industry: 'Beauty & Spa',
+                    location: 'Orchard Road, Singapore',
+                    manager: 'Marina Tan',
+                    contact: '+65 6900 2211',
+                    tagline: 'Premium skin rituals for instant radiance',
+                    metrics: {
+                        appointments: 96,
+                        satisfaction: '4.6 / 5',
+                        revenue: '$14.7K'
+                    }
+                },
+                {
+                    id: 'style-lounge',
+                    name: 'The Style Lounge',
+                    industry: 'Salon & Grooming',
+                    location: 'Joo Chiat, Singapore',
+                    manager: 'Ethan Low',
+                    contact: '+65 6120 0098',
+                    tagline: 'Creative styles for trendsetters',
+                    metrics: {
+                        appointments: 142,
+                        satisfaction: '4.9 / 5',
+                        revenue: '$20.1K'
+                    }
+                }
+            ];
+
+            const businessLookup = businesses.reduce((acc, business) => {
+                acc[business.id] = business;
+                return acc;
+            }, {});
+
             const businessOptions = [
                 { label: 'Select a business', value: '' },
-                { label: 'QTick Wellness Hub', value: 'QTick Wellness Hub' },
-                { label: 'Glow & Grow Spa', value: 'Glow & Grow Spa' },
-                { label: 'The Style Lounge', value: 'The Style Lounge' }
+                ...businesses.map(business => ({ label: business.name, value: business.id }))
             ];
+
+            const renderBusinessDetails = (container, businessId) => {
+                if (!container) return;
+                const business = businessLookup[businessId];
+                if (!business) {
+                    container.innerHTML = `
+                        <div class="rounded-lg border border-dashed border-slate-200 bg-white/60 p-4 text-sm text-slate-500">
+                            Select a business to preview owner, contact, and performance highlights.
+                        </div>
+                    `;
+                    return;
+                }
+
+                container.innerHTML = `
+                    <div class="rounded-xl border border-orange-200 bg-orange-50/60 p-4">
+                        <div class="flex items-center justify-between gap-4">
+                            <div>
+                                <h3 class="text-sm font-semibold text-orange-700">${business.name}</h3>
+                                <p class="text-xs text-orange-600 mt-1">${business.tagline}</p>
+                            </div>
+                            <span class="text-[10px] font-semibold uppercase tracking-wide text-orange-500">${business.industry}</span>
+                        </div>
+                        <dl class="mt-4 grid grid-cols-2 gap-3 text-xs text-slate-600">
+                            <div>
+                                <dt class="font-semibold text-slate-500 uppercase tracking-wide text-[10px]">Manager</dt>
+                                <dd class="mt-1 text-sm text-slate-800">${business.manager}</dd>
+                            </div>
+                            <div>
+                                <dt class="font-semibold text-slate-500 uppercase tracking-wide text-[10px]">Contact</dt>
+                                <dd class="mt-1 text-sm text-slate-800">${business.contact}</dd>
+                            </div>
+                            <div>
+                                <dt class="font-semibold text-slate-500 uppercase tracking-wide text-[10px]">Location</dt>
+                                <dd class="mt-1 text-sm text-slate-800">${business.location}</dd>
+                            </div>
+                            <div>
+                                <dt class="font-semibold text-slate-500 uppercase tracking-wide text-[10px]">Customer satisfaction</dt>
+                                <dd class="mt-1 text-sm text-slate-800">${business.metrics.satisfaction}</dd>
+                            </div>
+                        </dl>
+                    </div>
+                `;
+            };
+
+            const highlightBusinessCards = (cards, businessId) => {
+                cards.forEach(card => {
+                    const isActive = card.dataset.businessId === businessId;
+                    card.classList.toggle('border-orange-400', isActive);
+                    card.classList.toggle('shadow-lg', isActive);
+                    card.classList.toggle('ring-2', isActive);
+                    card.classList.toggle('ring-orange-200', isActive);
+                });
+            };
 
             const api = {
                 getTools: async () => {
@@ -736,18 +844,23 @@
                         return acc;
                     }, {});
                     toolCatalog.innerHTML = Object.entries(groupedTools).map(([category, toolList]) => `
-                        <section class="space-y-3">
+                        <section class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
                             <div class="flex items-center justify-between">
-                                <h3 class="font-semibold text-slate-500 text-xs uppercase tracking-wide">${category}</h3>
-                                <span class="text-[10px] font-medium text-slate-400">${toolList.length} tools</span>
+                                <div>
+                                    <h3 class="font-semibold text-slate-600 text-sm">${category}</h3>
+                                    <p class="text-[11px] text-slate-400 mt-1">${toolList.length} ${toolList.length === 1 ? 'tool' : 'tools'} available</p>
+                                </div>
+                                <span class="inline-flex items-center rounded-full bg-orange-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-orange-600">
+                                    <i class="fa-solid fa-layer-group mr-1"></i> Suite
+                                </span>
                             </div>
-                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                            <div class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
                                 ${toolList.map(tool => {
                                     const schema = toolSchemas[tool.name];
                                     const safeDescription = escapeAttribute(tool.description || '');
-                                    return `<button type="button" data-example="${tool.name}" class="tool-item tool-card w-full text-left rounded-xl border border-slate-200 bg-white p-4 shadow-sm hover:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-500/60">
+                                    return `<button type="button" data-example="${tool.name}" class="tool-item tool-card w-full text-left rounded-xl border border-slate-200 bg-slate-50 px-4 py-4 shadow-sm transition hover:border-orange-300 hover:bg-white focus:outline-none focus:ring-2 focus:ring-orange-500/60">
                                         <div class="flex items-start gap-3">
-                                            <div class="h-11 w-11 flex items-center justify-center rounded-lg bg-orange-50 text-orange-600">
+                                            <div class="h-11 w-11 flex items-center justify-center rounded-lg bg-orange-500/10 text-orange-600">
                                                 <i class="fa-solid ${schema.icon} text-lg"></i>
                                             </div>
                                             <div class="space-y-1">
@@ -755,9 +868,12 @@
                                                 <p class="text-xs text-slate-500 leading-snug">${safeDescription}</p>
                                             </div>
                                         </div>
-                                        <div class="mt-3 flex items-center text-xs font-medium text-orange-500">
-                                            <i class="fa-solid fa-bolt mr-2"></i>
-                                            Use tool
+                                        <div class="mt-4 flex items-center justify-between text-[11px] font-medium text-slate-500">
+                                            <span class="inline-flex items-center gap-2">
+                                                <i class="fa-solid fa-bolt text-orange-500"></i>
+                                                Trigger instantly
+                                            </span>
+                                            <i class="fa-solid fa-arrow-right text-slate-400"></i>
                                         </div>
                                     </button>`;
                                 }).join('')}
@@ -772,47 +888,120 @@
                 quickActions: () => {
                     if (!quickActionsList) return;
                     quickActionsList.innerHTML = `
-                        <div class="space-y-4">
-                            <div>
-                                <label for="business-select" class="block text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2">Business context</label>
-                                <div class="relative">
-                                    <select id="business-select" class="w-full appearance-none rounded-lg border border-slate-200 bg-white py-2.5 pl-3 pr-10 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-100">
-                                        ${businessOptions.map(option => {
-                                            const safeValue = escapeAttribute(option.value);
-                                            const safeLabel = escapeAttribute(option.label);
-                                            return `<option value="${safeValue}">${safeLabel}</option>`;
-                                        }).join('')}
-                                    </select>
-                                    <i class="fa-solid fa-store text-slate-400 absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none"></i>
+                        <div class="space-y-6">
+                            <section class="space-y-4">
+                                <div>
+                                    <label for="business-select" class="block text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2">Business context</label>
+                                    <div class="relative">
+                                        <select id="business-select" class="w-full appearance-none rounded-lg border border-slate-200 bg-white py-2.5 pl-3 pr-10 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-100">
+                                            ${businessOptions.map(option => {
+                                                const safeValue = escapeAttribute(option.value);
+                                                const safeLabel = escapeAttribute(option.label);
+                                                return `<option value="${safeValue}">${safeLabel}</option>`;
+                                            }).join('')}
+                                        </select>
+                                        <i class="fa-solid fa-store text-slate-400 absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none"></i>
+                                    </div>
                                 </div>
-                            </div>
-                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                                ${quickActions.map((action, index) => `
-                                    <button type="button" data-prompt="${action.prompt.replace(/"/g, '&quot;')}" class="quick-action-card w-full border border-slate-200 rounded-xl bg-white px-4 py-4 text-left shadow-sm hover:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-500/60">
-                                        <div class="flex items-center gap-3">
-                                            <div class="h-12 w-12 rounded-full flex items-center justify-center ${action.accent}">
-                                                <i class="fa-solid ${action.icon} text-lg"></i>
+                                <div id="selected-business-details"></div>
+                            </section>
+
+                            <section class="space-y-3">
+                                <div class="flex items-center justify-between">
+                                    <h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500">Available businesses</h3>
+                                    <span class="text-[11px] font-medium text-slate-400">${businesses.length} listed</span>
+                                </div>
+                                <div id="business-cards-grid" class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                                    ${businesses.map(business => `
+                                        <button type="button" data-business-id="${escapeAttribute(business.id)}" class="business-card w-full rounded-xl border border-slate-200 bg-white/90 px-4 py-4 text-left shadow-sm transition hover:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-500/60">
+                                            <div class="flex items-start justify-between gap-3">
+                                                <div>
+                                                    <h4 class="font-semibold text-slate-700">${escapeAttribute(business.name)}</h4>
+                                                    <p class="text-xs text-slate-500 mt-1">${escapeAttribute(business.location)}</p>
+                                                </div>
+                                                <span class="text-[10px] font-semibold uppercase tracking-wide text-slate-400">${escapeAttribute(business.industry)}</span>
                                             </div>
-                                            <div class="flex-1">
-                                                <p class="font-semibold text-slate-700">${action.label}</p>
-                                                <p class="text-xs text-slate-500 mt-1">QA-${index + 1}</p>
+                                            <dl class="mt-4 grid grid-cols-3 gap-2 text-[11px] text-slate-500">
+                                                <div class="rounded-lg bg-slate-50 p-2">
+                                                    <dt class="font-semibold text-slate-600 text-[10px] uppercase tracking-wide">Appointments</dt>
+                                                    <dd class="mt-1 text-sm text-slate-800">${escapeAttribute(String(business.metrics.appointments))}</dd>
+                                                </div>
+                                                <div class="rounded-lg bg-slate-50 p-2">
+                                                    <dt class="font-semibold text-slate-600 text-[10px] uppercase tracking-wide">Revenue</dt>
+                                                    <dd class="mt-1 text-sm text-slate-800">${escapeAttribute(business.metrics.revenue)}</dd>
+                                                </div>
+                                                <div class="rounded-lg bg-slate-50 p-2">
+                                                    <dt class="font-semibold text-slate-600 text-[10px] uppercase tracking-wide">Satisfaction</dt>
+                                                    <dd class="mt-1 text-sm text-slate-800">${escapeAttribute(business.metrics.satisfaction)}</dd>
+                                                </div>
+                                            </dl>
+                                            <p class="mt-4 text-[11px] font-medium text-orange-500">Tap to set context</p>
+                                        </button>
+                                    `).join('')}
+                                </div>
+                            </section>
+
+                            <section class="space-y-3">
+                                <div class="flex items-center justify-between">
+                                    <h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500">Quick actions</h3>
+                                    <span class="text-[11px] font-medium text-slate-400">${quickActions.length} prompts</span>
+                                </div>
+                                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                    ${quickActions.map((action, index) => `
+                                        <button type="button" data-prompt="${action.prompt.replace(/"/g, '&quot;')}" class="quick-action-card w-full border border-slate-200 rounded-xl bg-white px-4 py-4 text-left shadow-sm hover:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-500/60">
+                                            <div class="flex items-center gap-3">
+                                                <div class="h-12 w-12 rounded-full flex items-center justify-center ${action.accent}">
+                                                    <i class="fa-solid ${action.icon} text-lg"></i>
+                                                </div>
+                                                <div class="flex-1">
+                                                    <p class="font-semibold text-slate-700">${action.label}</p>
+                                                    <p class="text-xs text-slate-500 mt-1">QA-${index + 1}</p>
+                                                </div>
+                                                <i class="fa-solid fa-arrow-up-right-from-square text-slate-400"></i>
                                             </div>
-                                            <i class="fa-solid fa-arrow-up-right-from-square text-slate-400"></i>
-                                        </div>
-                                    </button>
-                                `).join('')}
-                            </div>
+                                        </button>
+                                    `).join('')}
+                                </div>
+                            </section>
                         </div>
                     `;
+
+                    const businessSelect = document.getElementById('business-select');
+                    const businessDetails = document.getElementById('selected-business-details');
+                    const businessCards = Array.from(quickActionsList.querySelectorAll('[data-business-id]'));
+
+                    const updateBusinessContext = (businessId) => {
+                        renderBusinessDetails(businessDetails, businessId);
+                        highlightBusinessCards(businessCards, businessId);
+                    };
+
+                    if (businessSelect) {
+                        businessSelect.addEventListener('change', () => updateBusinessContext(businessSelect.value));
+                        updateBusinessContext(businessSelect.value);
+                    }
                 }
             };
             quickActionsList.addEventListener('click', (event) => {
+                const businessCard = event.target.closest('[data-business-id]');
+                if (businessCard) {
+                    const businessSelect = document.getElementById('business-select');
+                    if (businessSelect) {
+                        const businessId = businessCard.dataset.businessId;
+                        if (businessSelect.value !== businessId) {
+                            businessSelect.value = businessId;
+                        }
+                        businessSelect.dispatchEvent(new Event('change', { bubbles: true }));
+                    }
+                    return;
+                }
+
                 const card = event.target.closest('.quick-action-card[data-prompt]');
                 if (!card) return;
                 const prompt = card.dataset.prompt;
                 const businessSelect = document.getElementById('business-select');
-                const selectedBusiness = businessSelect ? businessSelect.value : '';
-                const promptWithBusiness = selectedBusiness ? `${prompt} for ${selectedBusiness}` : prompt;
+                const selectedBusinessId = businessSelect ? businessSelect.value : '';
+                const selectedBusiness = businessLookup[selectedBusinessId];
+                const promptWithBusiness = selectedBusiness ? `${prompt} for ${selectedBusiness.name}` : prompt;
                 chatInput.value = promptWithBusiness;
                 chatInput.focus();
                 chatForm.dispatchEvent(new Event('submit', { bubbles: true }));


### PR DESCRIPTION
## Summary
- expand the right-hand layout so the tool catalog gains more vertical space and add descriptive headers for both sections
- introduce detailed mock business metadata, render available business cards, and show contextual details when a business is selected
- refresh quick action prompts to incorporate the selected business name and update the tool catalog cards with richer styling

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d011d5a49c832ea6f55b8e6af994aa