### PR TITLE
Add role-aware quick actions and summaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,23 @@
                 <button id="tts-toggle-btn" class="text-slate-400 hover:text-orange-600" title="Toggle Voice Response">
                     <i class="fa-solid fa-volume-xmark"></i>
                 </button>
+                <div class="relative" id="role-switcher">
+                    <button id="role-switcher-btn" class="flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-orange-300 hover:text-orange-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400">
+                        <i class="fa-solid fa-user-tie text-orange-500"></i>
+                        <span id="role-switcher-label">Manager</span>
+                        <i class="fa-solid fa-angle-down text-xs"></i>
+                    </button>
+                    <div id="role-switcher-menu" class="absolute right-0 mt-2 w-40 overflow-hidden rounded-lg border border-slate-200 bg-white py-1 text-sm shadow-lg hidden">
+                        <button type="button" class="flex w-full items-center gap-2 px-4 py-2 text-left text-slate-600 transition hover:bg-orange-50" data-role-option="manager">
+                            <i class="fa-solid fa-clipboard-user text-slate-400"></i>
+                            Manager
+                        </button>
+                        <button type="button" class="flex w-full items-center gap-2 px-4 py-2 text-left text-slate-600 transition hover:bg-orange-50" data-role-option="ceo">
+                            <i class="fa-solid fa-chess-king text-slate-400"></i>
+                            CEO
+                        </button>
+                    </div>
+                </div>
                 <button id="settings-btn" class="text-slate-500 hover:text-orange-600">
                     <i class="fa-solid fa-cog text-xl"></i>
                 </button>
@@ -216,16 +233,21 @@
             const quickActionsList = document.getElementById('quick-actions-list');
             const tabButtons = document.querySelectorAll('[data-tab-target]');
             const tabPanels = document.querySelectorAll('[data-tab-panel]');
+            const roleSwitcherBtn = document.getElementById('role-switcher-btn');
+            const roleSwitcherMenu = document.getElementById('role-switcher-menu');
+            const roleSwitcherLabel = document.getElementById('role-switcher-label');
 
             let tools = [];
             let voiceEnabled = false;
             let currentLang = 'en-US';
             let recognition;
             let speechSubmitting = false;
+            let currentRole = 'manager';
 
             const STORAGE_KEYS = {
                 chat: 'qtick-chat-html',
-                context: 'qtick-chat-context'
+                context: 'qtick-chat-context',
+                role: 'qtick-role-preference'
             };
 
             const conversationMemory = {
@@ -242,6 +264,15 @@
                 lastAnalytics: null,
                 lastAction: null
             };
+
+            try {
+                const storedRole = localStorage.getItem(STORAGE_KEYS.role);
+                if (storedRole === 'ceo' || storedRole === 'manager') {
+                    currentRole = storedRole;
+                }
+            } catch (error) {
+                console.warn('Unable to restore stored role preference', error);
+            }
 
             const activeCharts = {};
             let contextCounter = 0;
@@ -316,7 +347,30 @@
                         appointments: 142,
                         occupancy: '89%',
                         satisfaction: '4.9 / 5'
-                    }
+                    },
+                    summaryMetrics: [
+                        { label: "Today's revenue", value: 'S$18,750', change: 6.2 },
+                        { label: 'Check-ins', value: '52', change: 3.1 },
+                        { label: 'Utilisation', value: '89%', change: 1.2 }
+                    ],
+                    events: [
+                        {
+                            time: '09:30',
+                            title: 'Follow up TechFin corporate lead',
+                            description: 'Priya to confirm wellness retreat package.',
+                            tag: 'Lead',
+                            icon: 'fa-user-plus',
+                            accent: 'bg-sky-100 text-sky-600'
+                        },
+                        {
+                            time: '13:00',
+                            title: 'Influencer wellness workshop',
+                            description: 'Setup aroma pods and welcome kits in studio two.',
+                            tag: 'Event',
+                            icon: 'fa-bullhorn',
+                            accent: 'bg-purple-100 text-purple-600'
+                        }
+                    ]
                 },
                 {
                     id: 'chillbreeze-anna-nagar',
@@ -327,7 +381,30 @@
                         appointments: 118,
                         occupancy: '82%',
                         satisfaction: '4.7 / 5'
-                    }
+                    },
+                    summaryMetrics: [
+                        { label: "Today's revenue", value: 'S$12,140', change: 4.5 },
+                        { label: 'Check-ins', value: '44', change: 2.4 },
+                        { label: 'Lead conversions', value: '7', change: 1.1 }
+                    ],
+                    events: [
+                        {
+                            time: '10:15',
+                            title: 'Call back bridal spa lead',
+                            description: 'Rakesh awaiting customised detox quote.',
+                            tag: 'Lead',
+                            icon: 'fa-phone-volume',
+                            accent: 'bg-amber-100 text-amber-600'
+                        },
+                        {
+                            time: '16:00',
+                            title: 'Neighbourhood wellness talk',
+                            description: 'Community event hosted with local yoga collective.',
+                            tag: 'Event',
+                            icon: 'fa-people-group',
+                            accent: 'bg-emerald-100 text-emerald-600'
+                        }
+                    ]
                 },
                 {
                     id: 'chillbreeze-adayar',
@@ -338,9 +415,46 @@
                         appointments: 126,
                         occupancy: '85%',
                         satisfaction: '4.8 / 5'
-                    }
+                    },
+                    summaryMetrics: [
+                        { label: "Today's revenue", value: 'S$14,680', change: 5.1 },
+                        { label: 'Check-ins', value: '47', change: 2.7 },
+                        { label: 'Spa packages upsold', value: '11', change: 3.4 }
+                    ],
+                    events: [
+                        {
+                            time: '11:00',
+                            title: 'Yacht club guest arrival',
+                            description: 'Coordinate premium detox ritual for visiting members.',
+                            tag: 'Event',
+                            icon: 'fa-sailboat',
+                            accent: 'bg-cyan-100 text-cyan-600'
+                        },
+                        {
+                            time: '18:30',
+                            title: 'Upsell follow-up for Ananya',
+                            description: 'Share membership benefits after evening therapy.',
+                            tag: 'Lead',
+                            icon: 'fa-comments',
+                            accent: 'bg-rose-100 text-rose-600'
+                        }
+                    ]
                 }
             ];
+
+            const branchConsolidatedSummary = {
+                lounges: chillbreezeLocations.length,
+                period: 'Week to date',
+                metrics: [
+                    { label: 'Total revenue', value: 'S$186,400', change: 8.4 },
+                    { label: 'Appointments completed', value: '386', change: 5.2 },
+                    { label: 'Active leads', value: '128', change: 6.1 }
+                ],
+                highlights: [
+                    'Orchard lounge delivered 40% of revenue via premium add-ons.',
+                    'Anna Nagar events pushed community conversions up 9% week-over-week.'
+                ]
+            };
 
             let selectedQuickActionsLocationId = chillbreezeLocations[0]?.id || '';
 
@@ -902,6 +1016,19 @@
                         <option value="${escapeAttribute(location.id)}">${escapeAttribute(location.name)}</option>
                     `).join('');
 
+                    const summaryMetrics = Array.isArray(selectedLocation.summaryMetrics) ? selectedLocation.summaryMetrics : [];
+                    const events = Array.isArray(selectedLocation.events) ? selectedLocation.events : [];
+                    const branchMetrics = branchConsolidatedSummary && Array.isArray(branchConsolidatedSummary.metrics) ? branchConsolidatedSummary.metrics : [];
+                    const branchHighlights = branchConsolidatedSummary && Array.isArray(branchConsolidatedSummary.highlights) ? branchConsolidatedSummary.highlights : [];
+
+                    const formatChangeBadge = (change) => {
+                        const formatted = formatChange(change);
+                        if (!formatted) return '';
+                        const isNegative = typeof change === 'number' ? change < 0 : String(change || '').trim().startsWith('-');
+                        const badgeClass = isNegative ? 'bg-rose-50 text-rose-600' : 'bg-emerald-50 text-emerald-600';
+                        return `<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold ${badgeClass}">${formatted}</span>`;
+                    };
+
                     const actionCards = quickActionTemplates.map(action => `
                         <div class="quick-action-card group w-full rounded-2xl border border-slate-200/80 bg-white px-5 py-5 shadow-sm transition hover:-translate-y-0.5 hover:border-orange-300 hover:shadow-lg" role="button" tabindex="0" data-template="${escapeAttribute(action.promptTemplate)}">
                             <div class="flex items-start gap-4">
@@ -928,38 +1055,147 @@
                         </div>
                     `).join('');
 
-                    quickActionsList.innerHTML = `
-                        <div class="flex flex-col gap-6">
-                            <section class="rounded-2xl border border-slate-200/80 bg-white/90 p-6 shadow-sm backdrop-blur">
-                                <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-                                    <div class="space-y-1">
-                                        <h3 class="text-base font-semibold text-slate-700">Business spotlight</h3>
-                                        <p class="text-xs text-slate-500">Switch lounges to tailor these ready-made prompts.</p>
-                                    </div>
-                                    <div class="sm:w-64">
-                                        <label for="business-select" class="mb-1 block text-xs font-medium uppercase tracking-wide text-slate-500">Business</label>
-                                        <select id="business-select" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-200/70">
-                                            ${businessOptions}
-                                        </select>
-                                    </div>
-                                </div>
-                                <p class="mt-4 text-xs text-slate-500">${escapeAttribute(selectedLocation.focus)}</p>
-                                <div class="mt-5 flex flex-col gap-4 rounded-xl bg-slate-50 px-4 py-4 text-slate-600 sm:flex-row sm:items-center sm:justify-between">
-                                    <div class="flex items-center gap-3">
-                                        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-orange-500/10 text-orange-500">
-                                            <i class="fa-solid fa-location-dot"></i>
-                                        </span>
-                                        <div>
-                                            <p class="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Located in</p>
-                                            <p class="text-sm font-semibold text-slate-800">${escapeAttribute(selectedLocation.area)}</p>
-                                        </div>
-                                    </div>
-                                    <p class="text-xs text-slate-500 sm:text-right">Tailor these prompts for ${escapeAttribute(selectedLocation.name)}.</p>
-                                </div>
-                            </section>
-                            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                                ${actionCards}
+                    const summaryCards = summaryMetrics.map(metric => {
+                        const label = escapeAttribute(metric.label || 'Metric');
+                        const value = escapeAttribute(metric.value ?? '-');
+                        const badge = formatChangeBadge(metric.change);
+                        return `
+                            <div class="flex flex-col gap-1 rounded-xl border border-slate-200 bg-white/90 p-3 shadow-sm">
+                                <p class="text-[11px] font-semibold uppercase tracking-wide text-slate-500">${label}</p>
+                                <p class="text-lg font-bold text-slate-800">${value}</p>
+                                ${badge || ''}
                             </div>
+                        `;
+                    }).join('');
+
+                    const eventsList = events.map(item => {
+                        const title = escapeAttribute(item.title || 'Event');
+                        const description = item.description ? `<p class="text-xs text-slate-500">${escapeAttribute(item.description)}</p>` : '';
+                        const tag = item.tag ? `<span class="inline-flex items-center rounded-full bg-orange-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-orange-500">${escapeAttribute(item.tag)}</span>` : '';
+                        const accent = escapeAttribute(item.accent || 'bg-slate-100 text-slate-500');
+                        const icon = escapeAttribute(item.icon || 'fa-calendar-day');
+                        const time = escapeAttribute(item.time || '');
+                        return `
+                            <li class="flex items-start gap-3 rounded-xl border border-slate-200 bg-white/95 px-3 py-3 shadow-sm">
+                                <span class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full ${accent}">
+                                    <i class="fa-solid ${icon}"></i>
+                                </span>
+                                <div class="flex-1 space-y-1">
+                                    <div class="flex items-start justify-between gap-2">
+                                        <div class="flex items-center gap-2">
+                                            <p class="text-sm font-semibold text-slate-700">${title}</p>
+                                            ${tag}
+                                        </div>
+                                        <span class="text-xs font-medium text-slate-400">${time}</span>
+                                    </div>
+                                    ${description}
+                                </div>
+                            </li>
+                        `;
+                    }).join('');
+
+                    const branchCards = branchMetrics.map(metric => {
+                        const label = escapeAttribute(metric.label || 'Metric');
+                        const value = escapeAttribute(metric.value ?? '-');
+                        const badge = formatChangeBadge(metric.change);
+                        return `
+                            <div class="flex flex-col gap-1 rounded-xl border border-slate-200 bg-white/90 p-3 shadow-sm">
+                                <p class="text-[11px] font-semibold uppercase tracking-wide text-slate-500">${label}</p>
+                                <p class="text-lg font-bold text-slate-800">${value}</p>
+                                ${badge || ''}
+                            </div>
+                        `;
+                    }).join('');
+
+                    const branchHighlightList = branchHighlights.length
+                        ? `<ul class="mt-3 list-disc space-y-1 pl-5 text-xs text-slate-500">${branchHighlights.map(item => `<li>${escapeAttribute(item)}</li>`).join('')}</ul>`
+                        : '';
+
+                    const spotlightSection = `
+                        <section class="rounded-2xl border border-slate-200/80 bg-white/90 p-4 shadow-sm backdrop-blur">
+                            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                <div class="space-y-1">
+                                    <h3 class="text-sm font-semibold text-slate-700">Business spotlight</h3>
+                                    <p class="text-xs text-slate-500">Switch lounges to tailor these ready-made prompts.</p>
+                                </div>
+                                <div class="sm:w-64">
+                                    <label for="business-select" class="mb-1 block text-xs font-medium uppercase tracking-wide text-slate-500">Business</label>
+                                    <select id="business-select" class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-200/70">
+                                        ${businessOptions}
+                                    </select>
+                                </div>
+                            </div>
+                            <p class="mt-3 text-xs text-slate-500">${escapeAttribute(selectedLocation.focus)}</p>
+                            <div class="mt-3 flex flex-col gap-3 rounded-xl bg-slate-50 px-3 py-3 text-slate-600 sm:flex-row sm:items-center sm:justify-between">
+                                <div class="flex items-center gap-3">
+                                    <span class="flex h-9 w-9 items-center justify-center rounded-full bg-orange-500/10 text-orange-500">
+                                        <i class="fa-solid fa-location-dot"></i>
+                                    </span>
+                                    <div>
+                                        <p class="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Located in</p>
+                                        <p class="text-sm font-semibold text-slate-800">${escapeAttribute(selectedLocation.area)}</p>
+                                    </div>
+                                </div>
+                                <p class="text-xs text-slate-500 sm:text-right">Tailor these prompts for ${escapeAttribute(selectedLocation.name)}.</p>
+                            </div>
+                        </section>
+                    `;
+
+                    const businessSummarySection = `
+                        <section class="rounded-2xl border border-slate-200/80 bg-white/95 p-4 shadow-sm backdrop-blur-sm">
+                            <div class="flex items-start justify-between gap-2">
+                                <div>
+                                    <h3 class="text-sm font-semibold text-slate-700">Business summary</h3>
+                                    <p class="text-xs text-slate-500">Snapshot for ${escapeAttribute(selectedLocation.name)}</p>
+                                </div>
+                                <span class="inline-flex items-center rounded-full bg-slate-100 px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-slate-500">Manager view</span>
+                            </div>
+                            ${summaryMetrics.length ? `<div class="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">${summaryCards}</div>` : `<p class="mt-3 text-xs text-slate-500">No summary metrics available.</p>`}
+                        </section>
+                    `;
+
+                    const eventsSection = `
+                        <section class="rounded-2xl border border-slate-200/80 bg-white/95 p-4 shadow-sm backdrop-blur-sm">
+                            <div class="flex items-start justify-between gap-2">
+                                <div>
+                                    <h3 class="text-sm font-semibold text-slate-700">Lead & business events</h3>
+                                    <p class="text-xs text-slate-500">What needs attention today.</p>
+                                </div>
+                                <i class="fa-solid fa-calendar-check text-slate-300"></i>
+                            </div>
+                            ${events.length ? `<ul class="mt-3 space-y-3">${eventsList}</ul>` : `<p class="mt-3 text-xs text-slate-500">No scheduled events for today.</p>`}
+                        </section>
+                    `;
+
+                    const branchSummarySection = `
+                        <section class="rounded-2xl border border-slate-200/80 bg-white/95 p-4 shadow-sm backdrop-blur-sm">
+                            <div class="flex items-start justify-between gap-2">
+                                <div>
+                                    <h3 class="text-sm font-semibold text-slate-700">Branch consolidate summary</h3>
+                                    <p class="text-xs text-slate-500">${escapeAttribute(branchConsolidatedSummary?.period || '')}${branchConsolidatedSummary?.lounges ? ` · ${escapeAttribute(String(branchConsolidatedSummary.lounges) + ' lounges')}` : ''}</p>
+                                </div>
+                                <span class="inline-flex items-center rounded-full bg-orange-50 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-orange-500">Executive</span>
+                            </div>
+                            ${branchMetrics.length ? `<div class="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">${branchCards}</div>` : `<p class="mt-3 text-xs text-slate-500">No consolidated data available.</p>`}
+                            ${branchHighlightList}
+                        </section>
+                    `;
+
+                    const sections = [spotlightSection];
+                    if (currentRole === 'manager') {
+                        sections.push(businessSummarySection, eventsSection);
+                    } else if (currentRole === 'ceo') {
+                        sections.push(branchSummarySection);
+                    }
+                    sections.push(`
+                        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            ${actionCards}
+                        </div>
+                    `);
+
+                    quickActionsList.innerHTML = `
+                        <div class="flex flex-col gap-5">
+                            ${sections.filter(Boolean).join('')}
                         </div>
                     `;
 
@@ -973,6 +1209,44 @@
                     }
                 }
             };
+
+            const ROLE_LABELS = { manager: 'Manager', ceo: 'CEO' };
+
+            const closeRoleMenu = () => {
+                if (roleSwitcherMenu) {
+                    roleSwitcherMenu.classList.add('hidden');
+                }
+            };
+
+            const updateRoleMenu = () => {
+                if (roleSwitcherLabel) {
+                    roleSwitcherLabel.textContent = ROLE_LABELS[currentRole] || ROLE_LABELS.manager;
+                }
+                if (roleSwitcherMenu) {
+                    roleSwitcherMenu.querySelectorAll('[data-role-option]').forEach(option => {
+                        const isActive = option.dataset.roleOption === currentRole;
+                        option.classList.toggle('bg-orange-50', isActive);
+                        option.classList.toggle('font-semibold', isActive);
+                    });
+                }
+            };
+
+            const setRole = (role) => {
+                if (role !== 'manager' && role !== 'ceo') return;
+                if (currentRole === role) {
+                    updateRoleMenu();
+                    return;
+                }
+                currentRole = role;
+                try {
+                    localStorage.setItem(STORAGE_KEYS.role, currentRole);
+                } catch (error) {
+                    console.warn('Unable to persist role preference', error);
+                }
+                updateRoleMenu();
+                render.quickActions();
+            };
+
             if (quickActionsList) {
                 const handleQuickAction = (card) => {
                     if (!card) return;
@@ -1007,6 +1281,34 @@
                     if (!card) return;
                     event.preventDefault();
                     handleQuickAction(card);
+                });
+            }
+
+            if (roleSwitcherBtn && roleSwitcherMenu) {
+                roleSwitcherBtn.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    roleSwitcherMenu.classList.toggle('hidden');
+                });
+
+                roleSwitcherMenu.addEventListener('click', (event) => {
+                    const option = event.target.closest('[data-role-option]');
+                    if (!option) return;
+                    event.preventDefault();
+                    closeRoleMenu();
+                    setRole(option.dataset.roleOption);
+                });
+
+                document.addEventListener('click', (event) => {
+                    if (!roleSwitcherMenu || roleSwitcherMenu.classList.contains('hidden')) return;
+                    if (roleSwitcherMenu.contains(event.target) || roleSwitcherBtn.contains(event.target)) return;
+                    closeRoleMenu();
+                });
+
+                document.addEventListener('keydown', (event) => {
+                    if (event.key === 'Escape') {
+                        closeRoleMenu();
+                    }
                 });
             }
 
@@ -1852,6 +2154,7 @@
                 chatForm.addEventListener('submit', handleChatSubmit);
                 tools = await api.getTools();
                 render.tools();
+                updateRoleMenu();
                 render.quickActions();
                 activateTab('tools');
                 setupRecognition(currentLang);


### PR DESCRIPTION
## Summary
- add a role switcher in the header so users can toggle between Manager and CEO views
- extend Chillbreeze location data with summary metrics, event details, and a branch-wide consolidated summary
- refresh the quick actions panel to reduce the business spotlight footprint and surface role-specific summary/event cards

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_b_68d021cb1694832e97d069c105d8463c